### PR TITLE
[Feature] Record와 Memo 엔티티에 필요한 필드 추가

### DIFF
--- a/src/main/java/com/cmc/mercury/domain/memo/entity/Memo.java
+++ b/src/main/java/com/cmc/mercury/domain/memo/entity/Memo.java
@@ -28,11 +28,20 @@ public class Memo extends BaseEntity {
     @JoinColumn(name = "record_detail_id", nullable = false)
     private RecordDetail recordDetail;
 
+    @Column(nullable = false)
+    private int acquiredExp;
+
+    // 기록 생성 시 추가되는 메모는 경험치 획득하지 않으므로 이를 구분하기 위한 필드
+    @Column(nullable = false)
+    private boolean isFirstMemo;
+
     @Builder
-    public Memo(String content, int gauge, RecordDetail recordDetail) {
+    public Memo(String content, int gauge, RecordDetail recordDetail, int acquiredExp, boolean isFirstMemo) {
         this.content = content;
         this.gauge = gauge;
         this.recordDetail = recordDetail;
+        this.acquiredExp = acquiredExp;
+        this.isFirstMemo = isFirstMemo;
     }
 
     // RecordDetail와의 연관관계 메서드

--- a/src/main/java/com/cmc/mercury/domain/record/entity/Record.java
+++ b/src/main/java/com/cmc/mercury/domain/record/entity/Record.java
@@ -33,15 +33,19 @@ public class Record extends BaseEntity {
     @OneToOne(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
     private RecordDetail recordDetail;
 
+    @Column(nullable = false)
+    private int acquiredExp;
+
     // 연관관계 메서드
     public void setRecordDetail(RecordDetail recordDetail) {
         this.recordDetail = recordDetail;
         recordDetail.setRecord(this);
     }
     @Builder
-    public Record(User user, Book book) {
+    public Record(User user, Book book, int acquiredExp) {
         this.user = user;
         this.book = book;
+        this.acquiredExp = acquiredExp;
     }
 
     // 메모 생성, 수정 시 Record와 RecordDetail의 updatedAt을 함께 업데이트


### PR DESCRIPTION
## ✨ PR 목적
<!-- 어떤 이유로 PR를 하셨나요? -->
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 내용
<!-- 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해 주세요. -->
1. Record 엔티티에 acquiredExp 필드 추가
2. Memo 엔티티에 acquiredExp 필드 추가
3. Memo 엔티티에 isFirstMemo 필드 추가

## 📸 작업 화면 스크린샷

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📍 관련 이슈 번호 [#49]

## 🎸 기타
<!-- 추가로 작성할 사항이 있다면 기입해 주세요. -->
- isFirstMemo는 Record와 Memo의 createdAt 사이에 아주 미세한 차이가 있어서 추가한 필드
- 어떻게든 createdAt을 이용해서 jpa repository method를 구현하려 했지만 실패...
