### PR TITLE
[Feature] 경험치 계산 시간을 서버 시간에서 단말 기준으로 변경

### DIFF
--- a/src/main/java/com/cmc/mercury/domain/timer/dto/TimerRequest.java
+++ b/src/main/java/com/cmc/mercury/domain/timer/dto/TimerRequest.java
@@ -3,11 +3,18 @@ package com.cmc.mercury.domain.timer.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDateTime;
+
 @Schema(title = "타이머 기록 생성 요청 형식")
 public record TimerRequest(
         @NotNull(message = "기록 시간은 필수입니다.")
         @Schema(description = "기록 시간(단위: 초)")
-        int seconds
+        int seconds,
+
+        @NotNull(message = "단말 시간은 필수입니다.")
+        @Schema(description = "사용자 단말 시간 (ISO-8601 형식)",
+                example = "2024-01-30T12:34:56")
+        LocalDateTime deviceTime
 ) {
 
 }

--- a/src/main/java/com/cmc/mercury/domain/timer/repository/TimerRepository.java
+++ b/src/main/java/com/cmc/mercury/domain/timer/repository/TimerRepository.java
@@ -12,5 +12,5 @@ public interface TimerRepository extends JpaRepository<Timer, Long> {
 
     List<Timer> findAllByUser_testUserId(Long testUserId);
 
-    List<Timer> findAllByUser_testUserIdAndCreatedAtBetween(Long testUserId, LocalDateTime startofDay, LocalDateTime endofDay);
+    List<Timer> findAllByUser_testUserIdAndCreatedAtBetween(Long testUserId, LocalDateTime startOfDay, LocalDateTime deviceTime);
 }

--- a/src/main/java/com/cmc/mercury/domain/timer/service/TimerService.java
+++ b/src/main/java/com/cmc/mercury/domain/timer/service/TimerService.java
@@ -33,7 +33,7 @@ public class TimerService {
 
         User user = userTestService.getOrCreateTestUser(testUserId);
 
-        int todayTotalExp = calculateTodayTotalExp(testUserId);
+        int todayTotalExp = calculateTodayTotalExp(testUserId, request.deviceTime());
 
         int newExp = calculateExp(request.seconds());
 
@@ -77,15 +77,14 @@ public class TimerService {
     }
 
     // 오늘 획득한 총 경험치 계산
-    private int calculateTodayTotalExp(Long testUserId) {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
-        LocalDateTime endOfDay = startOfDay.plusDays(1);
+    private int calculateTodayTotalExp(Long testUserId, LocalDateTime deviceTime) {
+
+        LocalDateTime startOfDay = deviceTime.toLocalDate().atStartOfDay();  // 오늘 하루(일일)의 기준은 device time으로 00시 00분 자정
 
         return timerRepository.findAllByUser_testUserIdAndCreatedAtBetween(
                         testUserId,
                         startOfDay,
-                        endOfDay
+                        deviceTime
                 ).stream()
                 .mapToInt(Timer::getAcquiredExp)
                 .sum();


### PR DESCRIPTION
## ✨ PR 목적
<!-- 어떤 이유로 PR를 하셨나요? -->
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 내용
<!-- 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해 주세요. -->
1. TimerRequest에 사용자 단말 시간 필드 추가
2. TimerService에서 하루 경험치를 계산할 때 '오늘 00:00 ~ 내일 00:00'에서 '오늘 00:00 ~ 단말시간'으로 변경

## 📸 작업 화면 스크린샷

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📍 관련 이슈 번호 [#49]

## 🎸 기타
<!-- 추가로 작성할 사항이 있다면 기입해 주세요. -->
