### PR TITLE
[Refactor] 재발급 전의 refresh token으로 요청 시 에러 반환 로직 추가

### DIFF
--- a/src/main/java/com/cmc/mercury/global/exception/ErrorCode.java
+++ b/src/main/java/com/cmc/mercury/global/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     // JWT
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Jwt401", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Jwt401", "만료된 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Jwt401", "만료된 refresh 토큰입니다."),
     TOKEN_TYPE_MISMATCH(HttpStatus.UNAUTHORIZED, "Jwt401", "토큰 타입이 일치하지 않습니다."),
     EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "Jwt401", "토큰이 없습니다.");
 

--- a/src/main/java/com/cmc/mercury/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cmc/mercury/global/jwt/JwtAuthenticationFilter.java
@@ -81,8 +81,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     String refreshToken = extractRefreshToken(request);
 
                     if (StringUtils.hasText(refreshToken)) {
-                        // Refresh Token 검증
+                        // Refresh Token이 유효한지 검증
                         jwtProvider.validateToken(refreshToken, "RefreshToken");
+                        // Refresh Token이 DB에 저장된 것과 일치하는지 검증
+                        jwtProvider.checkRefreshToken(refreshToken);
 
                         // Refresh Token이 유효하면 새로운 Access Token과 Refresh Token 발급
                         User user = jwtProvider.getUserFromToken(refreshToken);

--- a/src/main/java/com/cmc/mercury/global/jwt/JwtProvider.java
+++ b/src/main/java/com/cmc/mercury/global/jwt/JwtProvider.java
@@ -109,4 +109,23 @@ public class JwtProvider {
 
         return user;
     }
+
+    public void checkRefreshToken(String token) {
+
+        // 기존 Refresh Token이 DB에 저장된 것과 일치하는지 확인
+        User user = getUserFromToken(token);
+
+        String storedRefreshToken = user.getRefreshToken();
+        if (storedRefreshToken == null) {
+            // DB에 Refresh Token이 없는 경우 (이미 무효화된 경우)
+            throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+
+        if (!token.equals(user.getRefreshToken())) {
+            // DB의 Refresh Token과 일치하지 않으면 재사용 시도로 간주
+            user.updateRefreshToken(null);  // DB의 Refresh Token 무효화
+            userRepository.save(user);
+            throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+    }
 }


### PR DESCRIPTION
## ✨ PR 목적
<!-- 어떤 이유로 PR를 하셨나요? -->
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 내용
<!-- 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해 주세요. -->
만료되진 않았지만 재발급하기 전의 refresh token(db와 일치하지 않은 토큰)으로 요청해도 access와 refresh token을 재발급해주는 오류 수정

## 📸 작업 화면 스크린샷

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📍 관련 이슈 번호 [#58]

## 🎸 기타
<!-- 추가로 작성할 사항이 있다면 기입해 주세요. -->
