### PR TITLE
[Fix] isNewUser가 항상 false인 오류 수정

### DIFF
--- a/src/main/java/com/cmc/mercury/global/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/cmc/mercury/global/oauth/service/CustomOAuth2UserService.java
@@ -112,7 +112,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             // 반환된 DefaultOAuth2User는 나중에 @AuthenticationPrincipal로 받아서 필요한 정보를 꺼내 쓸 수 있음
             return new DefaultOAuth2User(
                     Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
-                    oAuth2User.getAttributes(),
+                    userAttributes, // 기존 attributes 대신 isNewUser 포함된 attributes
                     userNameAttributeName);
 
         } catch (Exception e) {


### PR DESCRIPTION
## ✨ PR 목적
<!-- 어떤 이유로 PR를 하셨나요? -->
- [ ] 기능 관련 작업
- [x] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 내용
<!-- 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해 주세요. -->
1. OAuth2User 객체를 생성할 때 isNewUser가 추가된 userAttributes를 사용하지 않아 항상 false인 오류 발생

## 📸 작업 화면 스크린샷

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📍 관련 이슈 번호 [ ]

## 🎸 기타
<!-- 추가로 작성할 사항이 있다면 기입해 주세요. -->
