### PR TITLE
[Fix] refresh token 정책 변경

### DIFF
--- a/src/main/java/com/cmc/mercury/domain/user/service/UserService.java
+++ b/src/main/java/com/cmc/mercury/domain/user/service/UserService.java
@@ -94,16 +94,17 @@ public class UserService {
 
         // 토큰 설정
         response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("Refresh-Token", refreshToken);
 
-        // Refresh Token 쿠키 설정
-        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setSecure(true);
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setDomain("mercuryplanet.co.kr");
-        refreshTokenCookie.setAttribute("SameSite", "None");
-        refreshTokenCookie.setMaxAge((int) refreshTokenValidity / 1000);
-        response.addCookie(refreshTokenCookie);
+//        // Refresh Token 쿠키 설정
+//        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+//        refreshTokenCookie.setHttpOnly(true);
+//        refreshTokenCookie.setSecure(true);
+//        refreshTokenCookie.setPath("/");
+//        refreshTokenCookie.setDomain("mercuryplanet.co.kr");
+//        refreshTokenCookie.setAttribute("SameSite", "None");
+//        refreshTokenCookie.setMaxAge((int) refreshTokenValidity / 1000);
+//        response.addCookie(refreshTokenCookie);
     }
 
     public User getUser(String accessToken) {

--- a/src/main/java/com/cmc/mercury/global/config/SecurityConfig.java
+++ b/src/main/java/com/cmc/mercury/global/config/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
         configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
-        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Refresh-Token"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);
 

--- a/src/main/java/com/cmc/mercury/global/config/WebConfig.java
+++ b/src/main/java/com/cmc/mercury/global/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOriginPatterns("*")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
-                .exposedHeaders("Authorization")  // Authorization 헤더 노출
+                .exposedHeaders("Authorization", "Refresh-Token")  // Authorization, refresh token 헤더 노출
                 .allowCredentials(true)  // 쿠키 허용을 위해 필요
                 .maxAge(3600);
     }

--- a/src/main/java/com/cmc/mercury/global/controller/AuthController.java
+++ b/src/main/java/com/cmc/mercury/global/controller/AuthController.java
@@ -1,8 +1,6 @@
 package com.cmc.mercury.global.controller;
 
 import com.cmc.mercury.domain.user.entity.User;
-import com.cmc.mercury.global.exception.CustomException;
-import com.cmc.mercury.global.exception.ErrorCode;
 import com.cmc.mercury.global.jwt.JwtProvider;
 import com.cmc.mercury.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,11 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 
@@ -35,7 +29,7 @@ public class AuthController {
     @PostMapping("/refresh")
     @Operation(summary = "refresh token 재발급", description = "access token 만료 시 refresh token을 통해 재발급을 요청합니다.")
     public SuccessResponse<?> refreshAccessToken(
-            @CookieValue(value = "refresh_token", required = false) String refreshToken, HttpServletResponse response) {
+            @RequestHeader(value = "Refresh-Token", required = false) String refreshToken, HttpServletResponse response) {
 
         log.info("Refresh Token을 이용한 Access Token 갱신 요청");
 
@@ -49,15 +43,18 @@ public class AuthController {
         // 새로운 Access Token을 헤더에 추가
         response.setHeader("Authorization", "Bearer " + newAccessToken);
 
-        // 새로운 Refresh Token을 쿠키에 설정
-        Cookie refreshTokenCookie = new Cookie("refresh_token", newRefreshToken);
-        refreshTokenCookie.setHttpOnly(true); // JavaScript에서 접근 방지
-        refreshTokenCookie.setSecure(true); // HTTPS만 허용
-        refreshTokenCookie.setPath("/"); // 모든 경로에서 접근 가능
-        refreshTokenCookie.setDomain("mercuryplanet.co.kr");  // 도메인 간 쿠키 공유
-        refreshTokenCookie.setAttribute("SameSite", "None");
-        refreshTokenCookie.setMaxAge((int) refreshTokenValidity / 1000); // ms를 초 단위로 변환
-        response.addCookie(refreshTokenCookie);
+//        // 새로운 Refresh Token을 쿠키에 설정
+//        Cookie refreshTokenCookie = new Cookie("refresh_token", newRefreshToken);
+//        refreshTokenCookie.setHttpOnly(true); // JavaScript에서 접근 방지
+//        refreshTokenCookie.setSecure(true); // HTTPS만 허용
+//        refreshTokenCookie.setPath("/"); // 모든 경로에서 접근 가능
+//        refreshTokenCookie.setDomain("mercuryplanet.co.kr");  // 도메인 간 쿠키 공유
+//        refreshTokenCookie.setAttribute("SameSite", "None");
+//        refreshTokenCookie.setMaxAge((int) refreshTokenValidity / 1000); // ms를 초 단위로 변환
+//        response.addCookie(refreshTokenCookie);
+
+        // 새로운 Refresh Token을 헤더에 추가
+        response.setHeader("Refresh-Token", newRefreshToken);
 
         return SuccessResponse.ok(new HashMap<>());
     }

--- a/src/main/java/com/cmc/mercury/global/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/cmc/mercury/global/oauth/handler/OAuth2SuccessHandler.java
@@ -52,19 +52,24 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.setHeader("Authorization", "Bearer " + accessToken);
         log.info("Header에 설정은 성공");
 
-        // Refresh Token은 보안을 위해 HttpOnly 쿠키로 설정
-        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
-        refreshTokenCookie.setHttpOnly(true); // JavaScript에서 접근 방지
-        refreshTokenCookie.setSecure(true); // HTTPS만 허용
-        refreshTokenCookie.setPath("/"); // 모든 경로에서 접근 가능
-        refreshTokenCookie.setDomain("mercuryplanet.co.kr");  // 도메인 간 쿠키 공유
-        refreshTokenCookie.setAttribute("SameSite", "None");
-        refreshTokenCookie.setMaxAge((int) refreshTokenValidity / 1000); // ms를 초 단위로 변환
-        response.addCookie(refreshTokenCookie);
+//        // Refresh Token은 보안을 위해 HttpOnly 쿠키로 설정
+//        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+//        refreshTokenCookie.setHttpOnly(true); // JavaScript에서 접근 방지
+//        refreshTokenCookie.setSecure(true); // HTTPS만 허용
+//        refreshTokenCookie.setPath("/"); // 모든 경로에서 접근 가능
+//        refreshTokenCookie.setDomain("mercuryplanet.co.kr");  // 도메인 간 쿠키 공유
+//        refreshTokenCookie.setAttribute("SameSite", "None");
+//        refreshTokenCookie.setMaxAge((int) refreshTokenValidity / 1000); // ms를 초 단위로 변환
+//        response.addCookie(refreshTokenCookie);
+
+        // Refresh Token을 헤더에 추가
+        response.setHeader("Refresh-Token", refreshToken);
+
 
         // 리다이렉트 URL에 토큰 포함하여 이동
         String targetUrl = UriComponentsBuilder.fromUriString("https://www.mercuryplanet.co.kr/login/success")
                 .queryParam("access_token", accessToken)
+                .queryParam("refresh_token", refreshToken)
                 .queryParam("isNewUser", isNewUser)
                 .build(true).toUriString();
 


### PR DESCRIPTION
## ✨ PR 목적
<!-- 어떤 이유로 PR를 하셨나요? -->
- [x] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 내용
<!-- 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해 주세요. -->
1. 웹의 쿠키를 앱에서 이어받는 것에서 문제 발생
-> refresh token을 쿠키에서 헤더로 설정하는 것으로 변경
2. 소셜로그인 성공 시 쿼리파람에 refresh token도 포함
3. 헤더에 refresh token도 노출시키도록 cors 설정

## 📸 작업 화면 스크린샷

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📍 관련 이슈 번호 [ ]

## 🎸 기타
<!-- 추가로 작성할 사항이 있다면 기입해 주세요. -->
