### PR TITLE
[Fix] 독서기록에서 기대하지 않은 응답들 수정

### DIFF
--- a/src/main/java/com/cmc/mercury/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/cmc/mercury/domain/memo/repository/MemoRepository.java
@@ -13,8 +13,8 @@ import java.util.Optional;
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
-    // RecordDetail의 모든 Memo들을 찾아서 업데이트 순으로 정렬 후 최상단 반환
-    Optional<Memo> findTopByRecordDetailOrderByUpdatedAtDesc(RecordDetail recordDetail);
+    // RecordDetail의 모든 Memo들을 찾아서 생성순으로 정렬 후 최상단 반환
+    Optional<Memo> findTopByRecordDetailOrderByCreatedAtDesc(RecordDetail recordDetail);
 
     // RecordDetail의 모든 Memo들을 찾아서 생성 순으로 정렬 후 반환
     List<Memo> findAllByRecordDetailOrderByCreatedAtDesc(RecordDetail recordDetail);

--- a/src/main/java/com/cmc/mercury/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/cmc/mercury/domain/memo/repository/MemoRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
-    // RecordDetail의 모든 Memo들을 찾아서 생성순으로 정렬 후 최상단 반환
+    // RecordDetail의 모든 Memo들을 찾아서 생성 순으로 정렬 후 최상단 반환
     Optional<Memo> findTopByRecordDetailOrderByCreatedAtDesc(RecordDetail recordDetail);
 
     // RecordDetail의 모든 Memo들을 찾아서 생성 순으로 정렬 후 반환

--- a/src/main/java/com/cmc/mercury/domain/record/dto/RecordDetailResponse.java
+++ b/src/main/java/com/cmc/mercury/domain/record/dto/RecordDetailResponse.java
@@ -32,7 +32,7 @@ public record RecordDetailResponse(
                         recordDetail.getUpdatedGauge(),
                         BookResponse.from(record.getBook()),
                         record.getCreatedAt(),
-                        latestMemo != null ? latestMemo.getUpdatedAt() : record.getUpdatedAt(),
+                        latestMemo != null ? latestMemo.getCreatedAt() : record.getUpdatedAt(),
                         memos
                 );
         }

--- a/src/main/java/com/cmc/mercury/domain/record/dto/RecordDetailResponse.java
+++ b/src/main/java/com/cmc/mercury/domain/record/dto/RecordDetailResponse.java
@@ -2,6 +2,7 @@ package com.cmc.mercury.domain.record.dto;
 
 import com.cmc.mercury.domain.book.dto.BookResponse;
 import com.cmc.mercury.domain.memo.dto.MemoResponse;
+import com.cmc.mercury.domain.memo.entity.Memo;
 import com.cmc.mercury.domain.record.entity.Record;
 import com.cmc.mercury.domain.record.entity.RecordDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,13 +26,13 @@ public record RecordDetailResponse(
         @Schema(description = "메모 객체 목록")
         List<MemoResponse> memos
 ) {
-        public static RecordDetailResponse of(Record record, RecordDetail detail, List<MemoResponse> memos) {
+        public static RecordDetailResponse of(Record record, RecordDetail recordDetail, Memo latestMemo, List<MemoResponse> memos) {
                 return new RecordDetailResponse(
                         record.getId(),
-                        detail.getUpdatedGauge(),
+                        recordDetail.getUpdatedGauge(),
                         BookResponse.from(record.getBook()),
                         record.getCreatedAt(),
-                        record.getUpdatedAt(),
+                        latestMemo != null ? latestMemo.getUpdatedAt() : record.getUpdatedAt(),
                         memos
                 );
         }

--- a/src/main/java/com/cmc/mercury/domain/record/dto/RecordResponse.java
+++ b/src/main/java/com/cmc/mercury/domain/record/dto/RecordResponse.java
@@ -1,11 +1,13 @@
 package com.cmc.mercury.domain.record.dto;
 
 import com.cmc.mercury.domain.book.dto.BookResponse;
+import com.cmc.mercury.domain.memo.entity.Memo;
 import com.cmc.mercury.domain.record.entity.Record;
 import com.cmc.mercury.domain.record.entity.RecordDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Schema(title = "기록 객체 응답 형식")
 public record RecordResponse (
@@ -25,14 +27,14 @@ public record RecordResponse (
         @Schema(description = "얻은 경험치")
         int acquiredExp
 ) {
-        public static RecordResponse of(Record record, RecordDetail detail, String content) {
+        public static RecordResponse of(Record record, RecordDetail recordDetail, Memo memo, String content) {
 
                 return new RecordResponse(
                         record.getId(),
-                        detail.getUpdatedGauge(),
+                        recordDetail.getUpdatedGauge(),
                         content,
                         record.getCreatedAt(),
-                        record.getUpdatedAt(),
+                        memo != null ? memo.getUpdatedAt() : record.getUpdatedAt(),
                         BookResponse.from(record.getBook()),
                         record.getAcquiredExp()
                 );

--- a/src/main/java/com/cmc/mercury/domain/record/dto/RecordResponse.java
+++ b/src/main/java/com/cmc/mercury/domain/record/dto/RecordResponse.java
@@ -34,7 +34,7 @@ public record RecordResponse (
                         recordDetail.getUpdatedGauge(),
                         content,
                         record.getCreatedAt(),
-                        memo != null ? memo.getUpdatedAt() : record.getUpdatedAt(),
+                        memo != null ? memo.getCreatedAt() : record.getUpdatedAt(),
                         BookResponse.from(record.getBook()),
                         record.getAcquiredExp()
                 );


### PR DESCRIPTION
## ✨ PR 목적
<!-- 어떤 이유로 PR를 하셨나요? -->
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 내용
<!-- 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해 주세요. -->
1. 메모 수정 시 독서기록의 updatedAt에 반영되지 않아야 함(근데 이건 4로 인해서 하든 안 하든 상관없어짐..)
2. 가장 최신 메모 삭제 시 독서기록의 updatedGauge 반영
3. 메모 정렬이 업데이트 순이 아닌 생성 순으로 수정
4. 독서기록 반환 시 독서기록의 updatedAt이 아닌 가장 최근 memo의 createdAt으로 반환
    - 메모 수정은 날짜에 영향을 미치지 않아야 하는데, 메모를 수정하면 독서기록의 updatedAt이 자동으로 갱신되기 때문

## 📸 작업 화면 스크린샷

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📍 관련 이슈 번호 [ ]

## 🎸 기타
<!-- 추가로 작성할 사항이 있다면 기입해 주세요. -->
